### PR TITLE
Fix location of jQuery

### DIFF
--- a/source/js/modules/example.js
+++ b/source/js/modules/example.js
@@ -7,7 +7,7 @@
 import * as core from "../core";
 // Here's jQuery in case you need it. If you're just doing DOM manipulation, you
 // probably won't need it. Recommend using core.dom module to handle node caching.
-// import $ from "lib/jquery/dist/jquery";
+// import $ from "jquery/dist/jquery";
 
 
 let $_jsElements = null;


### PR DESCRIPTION
Updated to reflect new location of jQuery.

I had copied example.js to write a new module and noticed this path error when compiling.